### PR TITLE
Added missing CUR fields

### DIFF
--- a/doc_source/product-columns.md
+++ b/doc_source/product-columns.md
@@ -78,7 +78,26 @@ The product columns provide metadata about the product that incurred the expense
   + Amazon Neptune
   + Amazon RDS
   + AWS Database Migration Service
+  
+## F<a name="product-details-F"></a>
 
+### product/fromLocation<a name="product-details-F-fromLocation"></a>
++ **Description:** Describes the location from which usage originated. \. 
++ **Sample values:** `External`, `US East (N. Virginia)`, `Global` 
++ **Services:**
+  + AWS DataTransfer
+  + Amazon CloudFront
+
+### product/fromLocationType<a name="product-details-F-fromLocationType"></a>
++ **Description:** Describes the location type from which usage the originated. \. 
++ **Sample values:** `AWS Region`, `AWS Edge Location`, `Other` 
++ **Services:**
+  + AWS DirectConnect
+  + AWS MediaConnect
+  + Amazon CloudFront
+  + Amazon Lightsail
+  + AWS Shield
+  
 ## G<a name="product-details-G"></a>
 
 ### product/gpu<a name="product-details-G-gpu"></a>
@@ -386,6 +405,26 @@ The product columns provide metadata about the product that incurred the expense
   + Amazon EC2
   + Amazon ECS
 
+### product/toLocation<a name="product-details-T-toLocation"></a>
++ **Description:** Describes the location usage destination. \. 
++ **Sample values:** `External`, `US East (N. Virginia)` 
++ **Services:**
+  + AWS DataTransfer
+  + Amazon CloudFront
+
+### product/toLocationType<a name="product-details-T-toLocationType"></a>
++ **Description:** Describes the destination location of the service usage. \. 
++ **Sample values:** `AWS Region`, `AWS Edge Location`, `Other` 
++ **Services:**
+  + AWSDataTransfer
+  + AWSDirectConnect
+  + AWSMediaConnect
+  + AWSShield
+  + AmazonCloudFront
+  + AmazonLightsail
+  + AmazonNeptune
+  + AmazonSNS
+  
 ## U<a name="product-details-U"></a>
 
 ### product/usagetype<a name="product-details-U-usage"></a>


### PR DESCRIPTION
The following fields were added:
toLocation
toLocationType
fromLocation
fromLocationType

These fields are used in the WHERE clause when calculating data charges across all services:
SELECT
  DISTINCT "lineitem/productcode",
  "lineitem/usagetype",
  "product/fromlocation",
  "product/tolocation",
  sum("lineitem/usageamount") / 1024 AS "TB's",
  sum("lineitem/blendedcost") AS cost
FROM
  < DATABASE >.< TABLE >
WHERE
  "lineitem/usagetype" LIKE '%Bytes%'
  AND (
    "lineitem/usagetype" LIKE '%In%'
    OR "lineitem/usagetype" LIKE '%Out%'
    OR "lineitem/usagetype" LIKE 'Nat%'
  )
  AND (
    "product/fromlocation" = ''
    OR "product/fromlocation" LIKE '%~(%'
  )
GROUP BY
  "lineitem/productcode",
  "lineitem/usagetype",
  "product/fromlocation",
  "product/tolocation"
ORDER BY
  sum("lineitem/blendedcost") DESC;

This query can be used to narrow down the main services which are causing data charges. Its a good overview but does not take it down to the actual individual AWS resources i.e. EC2 instance, specific NAT gateway.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
